### PR TITLE
Fixing execution for output of FeatureCounts (using Galaxy) and some make-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -6,6 +6,7 @@
     <stdio>
         <exit_code range="1:" />
     </stdio>
+    <version_command>multiqc -v</version_command>
     <command>
 <![CDATA[
 mkdir multiqc_WDir &&

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -101,13 +101,13 @@ multiqc multiqc_WDir
                 <option value="rnastar_counts">RNA STAR (reads per gene)</option>
             </param>
             <param name="input_file" type="data" format="txt, tabular" multiple="true" label="Result file" help="Select input datasets"/>
-            <param name="saveLog" type="boolean" checked="false" label="Save log file" help="Save the multiQC log file to the history. This is mostly useful for debugging purposes."/>
         </repeat>
+        <param name="saveLog" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Save log file" help="Save the multiQC log file to the history. This is mostly useful for debugging purposes."/>
     </inputs>
     <outputs>
         <data format="html" from_work_dir="multiqc_report.html" name="html_file" label="${tool.name} on ${on_string}: Webpage" />
         <data format="txt" name="text_file" from_work_dir="multiqc_data/multiqc.log" label="${tool.name} on ${on_string}: Log">
-            <filter>saveLog is True</filter>
+            <filter>saveLog</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -39,9 +39,13 @@ mkdir multiqc_WDir &&
         #end for
     #else if str($repeat.software) == "featurecounts":
         ## Checks for files ending in '.summary'
-        #for $k, $file in enumerate($repeat.input_file):
-            mkdir multiqc_WDir/${repeat.software}_${i}/file_${k} &&
-            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/file_${k}/${file.element_identifier}.summary' &&
+        #for $file in $repeat.input_file
+            #if $file.metadata.column_names and $file.metadata.column_names.find(',') != -1
+                echo '$file.metadata.column_names.replace(',','\t').replace('__ob__u','').replace('u__sq__','').replace('__sq__','').replace('__cb__','')' >> 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.summary' &&
+                cat '$file' >> 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.summary' &&
+            #else
+                ln -s '$file' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.summary' &&
+            #end if
         #end for
     #else if str($repeat.software) == "bismark":
         ## Checks for files ending in _SE_report.txt
@@ -249,7 +253,7 @@ MultiQC takes software output summaries/logs and creates a single report from th
 - Fastqc
 - Cutadapt / Trim Galore!
 - Tophat2
-- FeatureCounts
+- FeatureCounts (summary file with the column header in the first line or as metadata)
 - Samtools (stats, flagstat, dxstats)
 - Picard (MarkDuplicatesMetrics, CollectGCBiasMetrics, CollectInsertSizeMetrics, CollectAlignmentSummaryMetrics, CollectRnaSeqMetrics)
 - Bismark (Alignment report file)

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -6,11 +6,8 @@
     <requirements>
        <requirement type="package" version="@WRAPPER_VERSION@">multiqc</requirement>
     </requirements>
-    <stdio>
-        <exit_code range="1:" />
-    </stdio>
-    <version_command>multiqc -v</version_command>
-    <command>
+    <version_command>@WRAPPER_VERSION@</version_command>
+    <command detect_errors="aggressive">
 <![CDATA[
 mkdir multiqc_WDir &&
 

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -7,82 +7,82 @@
         <exit_code range="1:" />
     </stdio>
     <command>
-        mkdir multiqc_WDir;
+<![CDATA[
+mkdir multiqc_WDir &&
 
-        #for $i, $repeat in enumerate( $results )
-            mkdir multiqc_WDir/${repeat.software}_${i};
+#for $i, $repeat in enumerate( $results )
+    mkdir multiqc_WDir/${repeat.software}_${i} &&
 
-            #if str($repeat.software) == "fastqc":
-                ## Searches for files named "fastqc_data.txt"
-                #for $k, $file in enumerate($repeat.input_file):
-                    mkdir multiqc_WDir/${repeat.software}_${i}/file_${k};
-                    ln -s '${file}' multiqc_WDir/fastqc_${i}/file_${k}/fastqc_data.txt;
-                #end for
-            #else if str($repeat.software) == "tophat":
-                ## Searches for files ending in "align_summary.txt"
-                #for $file in $repeat.input_file:
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}align_summary.txt';
-                #end for
-            #else if str($repeat.software) == "bowtie2":
-                ## Searches for files containing 'reads; of these;'
-                #for $file in $repeat.input_file:
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt';
-                #end for
-            #else if str($repeat.software) == "cutadapt":
-                ## Searches for files containing 'This is cutadapt'
-                #for $file in $repeat.input_file:
-                    cat '${file}' > 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt';
-                    ## replace header for old cutadapt release
-                    sed -i .old 's/You are running/This is/' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt';
-                #end for
-            #else if str($repeat.software) == "featurecounts":
-                ## Checks for files ending in '.summary'
-                #for $k, $file in enumerate($repeat.input_file):
-                    mkdir multiqc_WDir/${repeat.software}_${i}/file_${k};
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/file_${k}/${file.element_identifier}.summary';
-                #end for
-            #else if str($repeat.software) == "bismark":
-                ## Checks for files ending in _SE_report.txt
-                #for $file in $repeat.input_file
-                    ln -s ${file} 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}_SE_report.txt';
-                #end for
-            #else if str($repeat.software) == "samtools":
-                ## Checks for files containing 'This file was produced by samtools stats'
-                #for $file in $repeat.input_file
-                    ln -s ${file} 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}';
-                #end for
-            #else if str($repeat.software) == "picard":
-                #for $file in $repeat.input_file
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}';
-                #end for
-            #else if str($repeat.software) == "samtools_idxstats":
-                ## Checks for files containing "idxstats" in the name
-                #for $file in $repeat.input_file
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}_idxstats.txt';
-                #end for
-            #else if str($repeat.software) == "htseq":
-                ## Checks for files containing "__too_low_aQual"
-                #for $file in $repeat.input_file
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}';
-                #end for
-            #else if str($repeat.software) == "rnastar_log":
-                ## Checks for files named Log.final.out
-                #for $k, $file in enumerate($repeat.input_file):
-                    mkdir 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}';
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}/Log.final.out';
-                #end for
-            #else if str($repeat.software) == "rnastar_counts":
-                ## Checks for files named ReadsPerGene.out.tab
-                #for $k, $file in enumerate($repeat.input_file):
-                    mkdir 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}';
-                    ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}/ReadsPerGene.out.tab';
-                #end for
-            #end if
+    #if str($repeat.software) == "fastqc":
+        ## Searches for files named "fastqc_data.txt"
+        #for $k, $file in enumerate($repeat.input_file):
+            mkdir multiqc_WDir/${repeat.software}_${i}/file_${k} &&
+            ln -s '${file}' multiqc_WDir/fastqc_${i}/file_${k}/fastqc_data.txt &&
         #end for
+    #else if str($repeat.software) == "tophat":
+        ## Searches for files ending in "align_summary.txt"
+        #for $file in $repeat.input_file:
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}align_summary.txt' &&
+        #end for
+    #else if str($repeat.software) == "bowtie2":
+        ## Searches for files containing 'reads; of these;'
+        #for $file in $repeat.input_file:
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt' &&
+        #end for
+    #else if str($repeat.software) == "cutadapt":
+        ## Searches for files containing 'This is cutadapt'
+        #for $file in $repeat.input_file:
+            cat '${file}' > 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt' &&
+            ## replace header for old cutadapt release
+            sed -i .old 's/You are running/This is/' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}.txt' &&
+        #end for
+    #else if str($repeat.software) == "featurecounts":
+        ## Checks for files ending in '.summary'
+        #for $k, $file in enumerate($repeat.input_file):
+            mkdir multiqc_WDir/${repeat.software}_${i}/file_${k} &&
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/file_${k}/${file.element_identifier}.summary' &&
+        #end for
+    #else if str($repeat.software) == "bismark":
+        ## Checks for files ending in _SE_report.txt
+        #for $file in $repeat.input_file
+            ln -s ${file} 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}_SE_report.txt' &&
+        #end for
+    #else if str($repeat.software) == "samtools":
+        ## Checks for files containing 'This file was produced by samtools stats'
+        #for $file in $repeat.input_file
+            ln -s ${file} 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}' &&
+        #end for
+    #else if str($repeat.software) == "picard":
+        #for $file in $repeat.input_file
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}' &&
+        #end for
+    #else if str($repeat.software) == "samtools_idxstats":
+        ## Checks for files containing "idxstats" in the name
+        #for $file in $repeat.input_file
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}_idxstats.txt' &&
+        #end for
+    #else if str($repeat.software) == "htseq":
+        ## Checks for files containing "__too_low_aQual"
+        #for $file in $repeat.input_file
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}' &&
+        #end for
+    #else if str($repeat.software) == "rnastar_log":
+        ## Checks for files named Log.final.out
+        #for $k, $file in enumerate($repeat.input_file):
+            mkdir 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}' &&
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}/Log.final.out' &&
+        #end for
+    #else if str($repeat.software) == "rnastar_counts":
+        ## Checks for files named ReadsPerGene.out.tab
+        #for $k, $file in enumerate($repeat.input_file):
+            mkdir 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}' &&
+            ln -s '${file}' 'multiqc_WDir/${repeat.software}_${i}/${file.element_identifier}/ReadsPerGene.out.tab' &&
+        #end for
+    #end if
+#end for
 
-        multiqc multiqc_WDir;
-
-    </command>
+multiqc multiqc_WDir
+    ]]></command>
     <inputs>
         <repeat name="results" title="Results" min="1">
             <param name="software" type="select" label="Software name" help="Which tool was used generate logs?">

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -237,7 +237,7 @@ multiqc multiqc_WDir
         </test>
     </tests>
 
-    <help>
+    <help><![CDATA[
 **What it does**
 
 MultiQC aggregates results from bioinformatics analyses across many samples into a single report. It takes results of multiple analyses and creates a report that can be viewed as a single beautiful web-page. It's a general use tool, perfect for summarizing the output from numerous bioinformatics tools.
@@ -265,7 +265,7 @@ Cyril Monjeaud and Yvan Le Bras
 
 `EnginesOn &lt;http://engineson.fr/&gt;`_ and Rennes GenOuest Bio-informatics Core Facility
 
-    </help>
+    ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btw354</citation>
     </citations>

--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,7 +1,10 @@
-<tool id="multiqc" name="multiqc" version="1.0.0.0">
+<tool id="multiqc" name="multiqc" version="@WRAPPER_VERSION@.0">
     <description>aggregate results from bioinformatics analyses into a single report</description>
+    <macros>
+        <token name="@WRAPPER_VERSION@">1.0.0</token>
+    </macros>
     <requirements>
-       <requirement type="package" version="1.0.0">multiqc</requirement>
+       <requirement type="package" version="@WRAPPER_VERSION@">multiqc</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />


### PR DESCRIPTION
Hi,

I tried MultiQC on summary files generated by featureCounts in Galaxy and the MultiQC report was empty: the column name in the summary files in Galaxy are defined as metadata and not as a first line (needed for MultiQC). 
I fixed this issue by extracting the column names from the metadata and add them on top of the input file before running MultiQC (only for files with column names in the metadata). 
I wanted to add a test for this case, but I did not find how to add column names as metadata in a test...

I fixed also the log output: the log file was generated even if the parameter controlling was `false`

I did also some make-up on the wrapper (to be closer to the [IUC best practices](http://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html)):

- Putting the `command` and `help` in `CDATA`
- Replacing `;` by `&&` in `command`
- Adding `version_command`
- Using a token for the version number (easier to update)
- Moving the exit code detection as tag in the `command`
- Adding the `truevalue` and `falsevalue` to the boolean input

I hope these changes will be ok for you

Bérénice