### PR TITLE
Fix multiqc number version

### DIFF
--- a/tools/multiqc/multiqc.xml
+++ b/tools/multiqc/multiqc.xml
@@ -1,7 +1,7 @@
 <tool id="multiqc" name="multiqc" version="@WRAPPER_VERSION@.0">
     <description>aggregate results from bioinformatics analyses into a single report</description>
     <macros>
-        <token name="@WRAPPER_VERSION@">1.0.0</token>
+        <token name="@WRAPPER_VERSION@">1.0</token>
     </macros>
     <requirements>
        <requirement type="package" version="@WRAPPER_VERSION@">multiqc</requirement>


### PR DESCRIPTION
Hi,
According to Bioconda, the multiqc version number is not 1.0.0 but [1.0](https://bioconda.github.io/recipes/multiqc/README.html)
 Best regards